### PR TITLE
Add SonarQube scanning to CI

### DIFF
--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -1,0 +1,25 @@
+name: SonarQube Scan
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  sonarqube:
+    name: SonarQube Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v7
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+        with:
+          args: >
+            -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }}

--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -15,6 +15,19 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest pytest-cov ruff
+      - name: Lint with ruff
+        run: ruff check --output-format=json --output-file=ruff-report.json .
+        continue-on-error: true
+      - name: Run tests with coverage
+        run: pytest --cov=. --cov-report=xml:coverage.xml || [ $? -eq 5 ]
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v7
         env:
@@ -23,3 +36,6 @@ jobs:
         with:
           args: >
             -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }}
+            -Dsonar.python.coverage.reportPaths=coverage.xml
+            -Dsonar.python.ruff.reportPaths=ruff-report.json
+            -Dsonar.qualitygate.wait=true

--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -18,11 +18,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install dependencies
-        run: |
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install pytest pytest-cov ruff
+        # requirements.txt is a decade-old pinned set (this is Miguel Grinberg's Flask
+        # Mega-Tutorial) with real internal conflicts (urllib3 vs elasticsearch vs
+        # requests) and packages that no longer build under modern Python at all. No
+        # tests exist yet that would need the app's own runtime deps, so skip it here
+        # -- whoever adds real tests will need to sort that dependency tree out then.
+        run: pip install pytest pytest-cov ruff
       - name: Lint with ruff
         run: ruff check --output-format=json --output-file=ruff-report.json .
         continue-on-error: true


### PR DESCRIPTION
Wires this repo's CI to the new self-hosted SonarQube instance (securecode.purplehax.com) as part of the shakeout batch before rolling out to the rest of the repos.